### PR TITLE
API changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.0.1 (2019-10-31)
+
+- Project reorganization
+- add setup.py packaging
+- **BREAKING** api changes: remove `termux` prefix from methods

--- a/termux/termux.py
+++ b/termux/termux.py
@@ -20,227 +20,225 @@ def camera_info():
     return out
 
 
-def termux_camera_photo():
+def camera_photo():
     out, rc, err = utils.execute('termux-camera-photo')
     if rc:
         raise Exception(err)
     return out
 
 
-def termux_clipboard_get():
+def clipboard_get():
     out, rc, err = utils.execute('termux-clipboard-get')
     if rc:
         raise Exception(err)
     return out
 
 
-def termux_clipboard_set():
+def clipboard_set():
     out, rc, err = utils.execute('termux-clipboard-set')
     if rc:
         raise Exception(err)
     return out
 
 
-def termux_contact_list():
+def contact_list():
     out, rc, err = utils.execute('termux-contact-list')
     if rc:
         raise Exception(err)
     return out
 
 
-def termux_dialog():
+def dialog():
     out, rc, err = utils.execute('termux-dialog')
     if rc:
         raise Exception(err)
     return out
 
 
-def termux_download():
+def download():
     out, rc, err = utils.execute('termux-download')
     if rc:
         raise Exception(err)
     return out
 
 
-def termux_fix_shebang():
+def fix_shebang():
     out, rc, err = utils.execute('termux-fix-shebang')
     if rc:
         raise Exception(err)
     return out
 
 
-def termux_info():
+def info():
     out, rc, err = utils.execute('termux-info')
     if rc:
         raise Exception(err)
     return out
 
 
-def termux_infrared_frequencies():
+def infrared_frequencies():
     out, rc, err = utils.execute('termux-infrared-frequencies')
     if rc:
         raise Exception(err)
     return out
 
 
-def termux_infrared_transmit():
+def infrared_transmit():
     out, rc, err = utils.execute('termux-infrared-transmit')
     if rc:
         raise Exception(err)
     return out
 
 
-def termux_location():
+def location():
     out, rc, err = utils.execute('termux-location')
     if rc:
         raise Exception(err)
     return out
 
 
-def termux_notification():
+def notification():
     out, rc, err = utils.execute('termux-notification')
     if rc:
         raise Exception(err)
     return out
 
 
-def termux_notification_remove():
+def notification_remove():
     out, rc, err = utils.execute('termux-notification-remove')
     if rc:
         raise Exception(err)
     return out
 
 
-def termux_open():
+def open():
     out, rc, err = utils.execute('termux-open')
     if rc:
         raise Exception(err)
     return out
 
 
-def termux_open_url():
+def open_url():
     out, rc, err = utils.execute('termux-open-url')
     if rc:
         raise Exception(err)
     return out
 
 
-def termux_reload_settings():
+def reload_settings():
     out, rc, err = utils.execute('termux-reload-settings')
     if rc:
         raise Exception(err)
     return out
 
 
-def termux_setup_storage():
+def setup_storage():
     out, rc, err = utils.execute('termux-setup-storage')
     if rc:
         raise Exception(err)
     return out
 
 
-def termux_share():
+def share():
     out, rc, err = utils.execute('termux-share')
     if rc:
         raise Exception(err)
     return out
 
 
-def termux_sms_inbox():
+def sms_inbox():
     out, rc, err = utils.execute('termux-sms-inbox')
     if rc:
         raise Exception(err)
     return out
 
 
-def termux_sms_send():
+def sms_send():
     out, rc, err = utils.execute('termux-sms-send')
     if rc:
         raise Exception(err)
     return out
 
 
-def termux_storage_get():
+def storage_get():
     out, rc, err = utils.execute('termux-storage-get')
     if rc:
         raise Exception(err)
     return out
 
 
-def termux_telephony_call():
+def telephony_call():
     out, rc, err = utils.execute('termux-telephony-call')
     if rc:
         raise Exception(err)
     return out
 
 
-def termux_telephony_cellinfo():
+def telephony_cellinfo():
     out, rc, err = utils.execute('termux-telephony-cellinfo')
     if rc:
         raise Exception(err)
     return out
 
 
-def termux_telephony_deviceinfo():
+def telephony_deviceinfo():
     out, rc, err = utils.execute('termux-telephony-deviceinfo')
     if rc:
         raise Exception(err)
     return out
 
 
-def termux_toast():
+def toast():
     out, rc, err = utils.execute('termux-toast')
     if rc:
         raise Exception(err)
     return out
 
 
-def termux_tts_engines():
+def tts_engines():
     out, rc, err = utils.execute('termux-tts-engines')
     if rc:
         raise Exception(err)
     return out
 
 
-def termux_tts_speak():
+def tts_speak():
     out, rc, err = utils.execute('termux-tts-speak')
     if rc:
         raise Exception(err)
     return out
 
 
-def termux_vibrate():
+def vibrate():
     out, rc, err = utils.execute('termux-vibrate')
     if rc:
         raise Exception(err)
     return out
 
 
-def termux_wake_lock():
+def wake_lock():
     out, rc, err = utils.execute('termux-wake-lock')
     if rc:
         raise Exception(err)
     return out
 
 
-def termux_wake_unlock():
+def wake_unlock():
     out, rc, err = utils.execute('termux-wake-unlock')
     if rc:
         raise Exception(err)
     return out
 
 
-def termux_wifi_connectioninfo():
+def wifi_connectioninfo():
     out, rc, err = utils.execute('termux-wifi-connectioninfo')
     if rc:
         raise Exception(err)
     return out
 
 
-def termux_wifi_scaninfo():
+def wifi_scaninfo():
     out, rc, err = utils.execute('termux-wifi-scaninfo')
     if rc:
         raise Exception(err)
     return out
-
-


### PR DESCRIPTION
# Description

+ Add a changelog
+ **BREAKING** changes to the api: remove the redundant `termux_` prefix from the all methods
If all the termux functions have the same signature, It would be better to use meta programming in order to generate the bindings. In the meantime let's provide a cleaner api.
